### PR TITLE
Add user defined secret string validation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -316,9 +316,15 @@ It is possible to edit and enhance the implementation of the signature and its s
 
 ### Signature Secret
 
-This JWT library imposes strict secret security as follows: the secret must be at least 12 characters in length; contain numbers; upper and lowercase letters; and one of the following special characters `*&!@%^#$`.
+This JWT library does not imposes strict secret string security. However a good practice could be to set a strict pattern to validate the secret.
 
 ```php
+# setting a secret string pattern for validation
+\ReallySimpleJWT\Validate::$secretPattern = '/^.*$/';
+
+// Same validation without special characters
+\ReallySimpleJWT\Validate::$secretPattern = /^.*(?=.{12,}+)(?=.*[0-9]+)(?=.*[A-Z]+)(?=.*[a-z]+).*$/;
+
 // Bad Secret
 secret123
 
@@ -326,12 +332,7 @@ secret123
 sec!ReT423*&
 ```
 
-The reason for this is that there are lots of [JWT Crackers](https://github.com/lmammino/jwt-cracker) available meaning weak secrets are easy to crack thus rendering the security JWT offers useless. However, the developer could change the secret pattern validation as follows
-
-```php
-// Same validation without special characters
-\ReallySimpleJWT\Validate::$secretPattern = /^.*(?=.{12,}+)(?=.*[0-9]+)(?=.*[A-Z]+)(?=.*[a-z]+).*$/;
-```
+The reason for this is that there are lots of [JWT Crackers](https://github.com/lmammino/jwt-cracker) available meaning weak secrets are easy to crack thus rendering the security JWT offers useless.
 
 ## Version One Support
 

--- a/readme.md
+++ b/readme.md
@@ -305,7 +305,7 @@ The ReallySimpleJWT library will in a number of situations throw exceptions to h
 | 6    | Expiration claim is not set.      | Attempt was made to validate an Expiration claim which does not exist. |
 | 7    | Not Before claim is not set.      | Attempt was made to validate a Not Before claim which does not exist. |
 | 8    | Invalid payload claim.            | Payload claims must be key value pairs of the format string:mixed. |
-| 9    | Invalid secret.                   | Must be 12 characters in length, contain upper and lower case letters, a number, and a special character `*&!@%^#$`` |
+| 9    | Invalid secret.                   | Must be 12 characters in length, contain upper and lower case letters, a number, and a special character `*&!@%^#$`` by default or user defined. |
 | 10   | Invalid Audience claim.           | The aud claim can either be a string or an array of strings nothing else. |
 
 ## Token Security
@@ -326,7 +326,12 @@ secret123
 sec!ReT423*&
 ```
 
-The reason for this is that there are lots of [JWT Crackers](https://github.com/lmammino/jwt-cracker) available meaning weak secrets are easy to crack thus rendering the security JWT offers useless.
+The reason for this is that there are lots of [JWT Crackers](https://github.com/lmammino/jwt-cracker) available meaning weak secrets are easy to crack thus rendering the security JWT offers useless. However, the developer could change the secret pattern validation as follows
+
+```php
+// Same validation without special characters
+\ReallySimpleJWT\Validate::$secretPattern = /^.*(?=.{12,}+)(?=.*[0-9]+)(?=.*[A-Z]+)(?=.*[a-z]+).*$/;
+```
 
 ## Version One Support
 

--- a/src/Validate.php
+++ b/src/Validate.php
@@ -17,7 +17,7 @@ namespace ReallySimpleJWT;
  * 6: Expiration claim is not set.
  * 7: Not Before claim is not set.
  * 8: Invalid payload claim: Claims must be key values of type string:mixed.
- * 9: Invalid secret: See README for more information.
+ * 9: Invalid secret: The secret string does not match the pattern
  * 10: Invalid Audience claim: Must be either a string or array of strings.
  *
  * @author Rob Waller <rdwaller1984@googlemail.com>
@@ -29,7 +29,7 @@ class Validate
      *
      * @var string
      */
-    public static $secretPattern = '/^.*(?=.{12,}+)(?=.*[0-9]+)(?=.*[A-Z]+)(?=.*[a-z]+)(?=.*[\*&!@%\^#\$]+).*$/';
+    public static $secretPattern = '/^.*$/';
 
     /**
      * Confirm the structure of a JSON Web Token, it has three parts separated

--- a/src/Validate.php
+++ b/src/Validate.php
@@ -25,6 +25,13 @@ namespace ReallySimpleJWT;
 class Validate
 {
     /**
+     * Validation for the secret string
+     *
+     * @var string
+     */
+    public static $secretPattern = '/^.*(?=.{12,}+)(?=.*[0-9]+)(?=.*[A-Z]+)(?=.*[a-z]+)(?=.*[\*&!@%\^#\$]+).*$/';
+
+    /**
      * Confirm the structure of a JSON Web Token, it has three parts separated
      * by dots and complies with Base64 URL standards.
      *
@@ -88,8 +95,7 @@ class Validate
     public function secret(string $secret): bool
     {
         if (!preg_match(
-            '/^.*(?=.{12,}+)(?=.*[0-9]+)(?=.*[A-Z]+)(?=.*[a-z]+)(?=.*[\*&!@%\^#\$]+).*$/',
-            $secret
+            self::$secretPattern, $secret
         )) {
             return false;
         }


### PR DESCRIPTION
In the actual repository is not possible to define the secret string validation. By default the JWT library uses the following pattern to validate the secret string:

`/^.*(?=.{12,}+)(?=.*[0-9]+)(?=.*[A-Z]+)(?=.*[a-z]+)(?=.*[\*&!@%\^#\$]+).*$/`

However, not all secret strings have special characters. The actual change does possible to change the secret string pattern validation as follows:

_***Example: drop special characters and numbers_
`\ReallySimpleJWT\Validate::$secretPattern = '/^.*(?=.*[A-Z]+)(?=.*[a-z]+).*$/'`